### PR TITLE
[windows] Always use system-shipped tar

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,13 @@ runs:
       run: |
         New-Item -ItemType Directory -Path "${{ inputs.path }}" -Force | Out-Null
         $TarFile = Join-Path "${{ steps.create-temp-dir.outputs.temp-dir }}" "${{ inputs.name }}.tar"
-        tar xf $TarFile -C ${{ inputs.path }}
+        if ($IsWindows) {
+          # Workaround issue where GNU tar from Git takes priority over Windows tar.
+          $Tar = "${env:WINDIR}\System32\tar.exe"
+        } else {
+          $Tar = "tar"
+        }
+        & $Tar xf $TarFile -C ${{ inputs.path }}
 
     - name: Delete Temporary Directory
       shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -38,13 +38,8 @@ runs:
       run: |
         New-Item -ItemType Directory -Path "${{ inputs.path }}" -Force | Out-Null
         $TarFile = Join-Path "${{ steps.create-temp-dir.outputs.temp-dir }}" "${{ inputs.name }}.tar"
-        if ($IsWindows) {
-          # Workaround issue where GNU tar from Git takes priority over Windows tar.
-          $Tar = "${env:WINDIR}\System32\tar.exe"
-        } else {
-          $Tar = "tar"
-        }
-        & $Tar xf $TarFile -C ${{ inputs.path }}
+        $tar = if ($IsWindows) { "${env:WINDIR}\System32\tar.exe" } else { "tar" }
+        & $tar xf $TarFile -C ${{ inputs.path }}
 
     - name: Delete Temporary Directory
       shell: pwsh


### PR DESCRIPTION
On some Windows runners, it is possible for a GNU tar binary to be further ahead in `PATH`. In particular, Git for Windows ships with a GNU tar binary, which can't parse Windows-style paths properly. This works around the issue by always using the BSD tar binary that always ships with the operating system on Windows.